### PR TITLE
Feat: 전체 건물의 전기 사용량을 가져오는 API 추가

### DIFF
--- a/src/main/java/com/capstone/carbonlive/controller/ElectricityController.java
+++ b/src/main/java/com/capstone/carbonlive/controller/ElectricityController.java
@@ -2,13 +2,12 @@ package com.capstone.carbonlive.controller;
 
 import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
+import com.capstone.carbonlive.dto.UsageWithNameResponse;
 import com.capstone.carbonlive.service.ElectricityService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/electricity")
@@ -19,5 +18,12 @@ public class ElectricityController {
     public ResponseEntity<UsageResult<UsageResponse>> getElectricityEach(@PathVariable(name = "buildingCode") Long id){
         UsageResult<UsageResponse> usageResult = electricityService.getEachAll(id);
         return ResponseEntity.ok(usageResult);
+    }
+
+    @GetMapping("/area")
+    @ResponseStatus(HttpStatus.OK)
+    public UsageResult<UsageWithNameResponse> getElectricityAll(){
+        UsageResult<UsageWithNameResponse> result = electricityService.getAll();
+        return result;
     }
 }

--- a/src/main/java/com/capstone/carbonlive/dto/UsageResult.java
+++ b/src/main/java/com/capstone/carbonlive/dto/UsageResult.java
@@ -11,4 +11,8 @@ public class UsageResult<T> {
     public UsageResult(List<T> result) {
         this.result = result;
     }
+
+    public void add(T element){
+        this.result.add(element);
+    }
 }

--- a/src/main/java/com/capstone/carbonlive/dto/UsageWithNameResponse.java
+++ b/src/main/java/com/capstone/carbonlive/dto/UsageWithNameResponse.java
@@ -2,8 +2,10 @@ package com.capstone.carbonlive.dto;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class UsageWithNameResponse {
     private String name;
-    private UsageResult<UsageResponse> usages;
+    private List<UsageResponse> usagesList;
 }

--- a/src/main/java/com/capstone/carbonlive/dto/UsageWithNameResponse.java
+++ b/src/main/java/com/capstone/carbonlive/dto/UsageWithNameResponse.java
@@ -1,0 +1,9 @@
+package com.capstone.carbonlive.dto;
+
+import lombok.Data;
+
+@Data
+public class UsageWithNameResponse {
+    private String name;
+    private UsageResult<UsageResponse> usages;
+}

--- a/src/main/java/com/capstone/carbonlive/service/ElectricityService.java
+++ b/src/main/java/com/capstone/carbonlive/service/ElectricityService.java
@@ -2,7 +2,9 @@ package com.capstone.carbonlive.service;
 
 import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
+import com.capstone.carbonlive.dto.UsageWithNameResponse;
 
 public interface ElectricityService {
     UsageResult<UsageResponse> getEachAll(Long id);
+    UsageResult<UsageWithNameResponse> getAll();
 }

--- a/src/main/java/com/capstone/carbonlive/service/ElectricityServiceImpl.java
+++ b/src/main/java/com/capstone/carbonlive/service/ElectricityServiceImpl.java
@@ -2,6 +2,7 @@ package com.capstone.carbonlive.service;
 
 import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
+import com.capstone.carbonlive.dto.UsageWithNameResponse;
 import com.capstone.carbonlive.entity.Building;
 import com.capstone.carbonlive.entity.Electricity;
 import com.capstone.carbonlive.repository.BuildingRepository;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.capstone.carbonlive.service.common.GetUsageResult.getUsageResult;
@@ -29,5 +31,21 @@ public class ElectricityServiceImpl implements ElectricityService {
                 Sort.by("recordedAt").ascending());
 
         return getUsageResult(electricityList);
+    }
+
+    @Override
+    public UsageResult<UsageWithNameResponse> getAll() {
+        UsageResult<UsageWithNameResponse> result = new UsageResult<>(new ArrayList<>());
+
+        List<Building> buildings = buildingRepository.findAll();
+        for (Building b : buildings){
+            UsageWithNameResponse response = new UsageWithNameResponse();
+            response.setName(b.getName());
+            UsageResult<UsageResponse> usageResult = getEachAll(b.getId());
+            response.setUsages(usageResult);
+            result.add(response);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/capstone/carbonlive/service/ElectricityServiceImpl.java
+++ b/src/main/java/com/capstone/carbonlive/service/ElectricityServiceImpl.java
@@ -42,7 +42,7 @@ public class ElectricityServiceImpl implements ElectricityService {
             UsageWithNameResponse response = new UsageWithNameResponse();
             response.setName(b.getName());
             UsageResult<UsageResponse> usageResult = getEachAll(b.getId());
-            response.setUsages(usageResult);
+            response.setUsagesList(usageResult.getResult());
             result.add(response);
         }
 

--- a/src/test/java/com/capstone/carbonlive/controller/ElectricityControllerTest.java
+++ b/src/test/java/com/capstone/carbonlive/controller/ElectricityControllerTest.java
@@ -2,6 +2,7 @@ package com.capstone.carbonlive.controller;
 
 import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
+import com.capstone.carbonlive.dto.UsageWithNameResponse;
 import com.capstone.carbonlive.restdocs.AbstractRestDocsTest;
 import com.capstone.carbonlive.service.ElectricityService;
 import org.junit.jupiter.api.Test;
@@ -74,5 +75,58 @@ class ElectricityControllerTest extends AbstractRestDocsTest {
                 ));
 
         then(electricityService).should(times(1)).getEachAll(1L);
+    }
+
+    @Test
+    void getElectricityAll() throws Exception {
+        // given
+        UsageResult<UsageWithNameResponse> result = new UsageResult<>(new ArrayList<>());
+        UsageWithNameResponse response1 = new UsageWithNameResponse();
+        response1.setName("본관");
+        UsageWithNameResponse response2 = new UsageWithNameResponse();
+        response2.setName("60주년기념관");
+
+        UsageResult<UsageResponse> usageResult = new UsageResult<>(new ArrayList<>());
+        int[] usages1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        int[] usages2 = {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+        UsageResponse usageResponse1 = new UsageResponse(2017);
+        usageResponse1.setUsages(usages1);
+        UsageResponse usageResponse2 = new UsageResponse(2018);
+        usageResponse2.setUsages(usages2);
+        usageResult.add(usageResponse1);
+        usageResult.add(usageResponse2);
+
+        response1.setUsagesList(usageResult.getResult());
+        response2.setUsagesList(usageResult.getResult());
+
+        result.add(response1);
+        result.add(response2);
+
+        given(electricityService.getAll())
+                .willReturn(result);
+        // when
+        this.mockMvc.perform(get(uri + "/area")
+                            .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].name").value("본관"))
+                .andExpect(jsonPath("$.result[1].name").value("60주년기념관"))
+                .andExpect(jsonPath("$.result[1].usagesList.length()").value(2))
+                .andExpect(jsonPath("$.result[1].usagesList[0].year").value(2017))
+                .andExpect(jsonPath("$.result[1].usagesList[1].usages[11]").value(24))
+                .andDo(print())
+                .andDo(document("{class-name}/{method-name}",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("result").description("결과 반환"),
+                                fieldWithPath("result[].name").description("건물명"),
+                                fieldWithPath("result[].usagesList").description("사용량 데이터"),
+                                fieldWithPath("result[].usagesList[].year").description("해당 사용량 데이터의 년도"),
+                                fieldWithPath("result[].usagesList[].usages").description("월별 사용량(1월-12월)")
+                        )
+                ));
+
+        // then
+        then(electricityService).should(times(1)).getAll();
     }
 }

--- a/src/test/java/com/capstone/carbonlive/service/ElectricityServiceTest.java
+++ b/src/test/java/com/capstone/carbonlive/service/ElectricityServiceTest.java
@@ -94,7 +94,7 @@ class ElectricityServiceTest {
         assertThat(result.get(0).getName()).isEqualTo(this.name[0]);
         assertThat(result.get(1).getName()).isEqualTo(this.name[1]);
 
-        IntStream.rangeClosed(0, 11).forEach(i -> assertThat(result.get(1).getUsages().getResult().get(0).getUsages()[i]).isEqualTo(expectUsages[0][i]));
+        IntStream.rangeClosed(0, 11).forEach(i -> assertThat(result.get(1).getUsagesList().get(0).getUsages()[i]).isEqualTo(expectUsages[0][i]));
 
     }
 }


### PR DESCRIPTION
**UsageResult.java**
* result 필드에 요소를 추가하는 ```add()``` 메서드 생성. 기존에 result 필드에 요소를 추가하려면 ```.getResult().add()```라는 번거로운 과정을 거쳐야 했음.

**UsageWithNameResponse.java**
* 해당 API를 위한 또다른 DTO.

**ElectricityServiceImpl.java**
* 전체 건물들의 사용량을 얻어오는 ```getAll()``` 메서드 추가. ```buildingRepository```에서 건물들을 전부 가지고 온 뒤, ```for``` 문으로 건물들을 돌며 ```getEachAll()``` 메서드를 실행해 전부 가져온다.

