### PR TITLE
Feat: 건물별 탄소 배출량 API  추가

### DIFF
--- a/src/main/java/com/capstone/carbonlive/controller/CarbonController.java
+++ b/src/main/java/com/capstone/carbonlive/controller/CarbonController.java
@@ -1,14 +1,13 @@
 package com.capstone.carbonlive.controller;
 
 import com.capstone.carbonlive.dto.CarbonYearResponse;
+import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
 import com.capstone.carbonlive.service.CarbonService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/carbon")
@@ -20,5 +19,10 @@ public class CarbonController {
     @ResponseStatus(HttpStatus.OK)
     public UsageResult<CarbonYearResponse> getYearUsages(){
         return carbonService.getYearsUsages();
+    }
+
+    @GetMapping("/{buildingCode}")
+    public ResponseEntity<UsageResult<UsageResponse>> getBuildingUsages(@PathVariable("buildingCode") Long buildingCode ) {
+        return ResponseEntity.ok(carbonService.getBuildingUsages(buildingCode));
     }
 }

--- a/src/main/java/com/capstone/carbonlive/repository/CarbonRepository.java
+++ b/src/main/java/com/capstone/carbonlive/repository/CarbonRepository.java
@@ -1,7 +1,11 @@
 package com.capstone.carbonlive.repository;
 
+import com.capstone.carbonlive.entity.Building;
 import com.capstone.carbonlive.entity.Carbon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CarbonRepository extends JpaRepository<Carbon, Long> {
+    List<Carbon> findByBuildingOrderByRecordedAtAsc(Building building);
 }

--- a/src/main/java/com/capstone/carbonlive/service/CarbonService.java
+++ b/src/main/java/com/capstone/carbonlive/service/CarbonService.java
@@ -1,8 +1,10 @@
 package com.capstone.carbonlive.service;
 
 import com.capstone.carbonlive.dto.CarbonYearResponse;
+import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
 
 public interface CarbonService {
     UsageResult<CarbonYearResponse> getYearsUsages();
+    UsageResult<UsageResponse> getBuildingUsages(Long buildingId);
 }

--- a/src/main/java/com/capstone/carbonlive/service/CarbonServiceImpl.java
+++ b/src/main/java/com/capstone/carbonlive/service/CarbonServiceImpl.java
@@ -1,9 +1,13 @@
 package com.capstone.carbonlive.service;
 
 import com.capstone.carbonlive.dto.CarbonYearResponse;
+import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
+import com.capstone.carbonlive.entity.Building;
 import com.capstone.carbonlive.entity.Carbon;
+import com.capstone.carbonlive.repository.BuildingRepository;
 import com.capstone.carbonlive.repository.CarbonRepository;
+import com.capstone.carbonlive.service.common.GetUsageResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -11,10 +15,13 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.capstone.carbonlive.service.common.GetUsageResult.*;
+
 @Service
 @RequiredArgsConstructor
 public class CarbonServiceImpl implements CarbonService{
     private final CarbonRepository carbonRepository;
+    private final BuildingRepository buildingRepository;
 
     @Override
     public UsageResult<CarbonYearResponse> getYearsUsages() {
@@ -39,5 +46,14 @@ public class CarbonServiceImpl implements CarbonService{
         result.getResult().remove(0); // 최초 year = -1 인 부분 삭제.
 
         return result;
+    }
+
+    @Override
+    public UsageResult<UsageResponse> getBuildingUsages(Long buildingId) {
+        Building building = buildingRepository.findById(buildingId).orElseThrow(RuntimeException::new);
+
+        List<Carbon> carbonList = carbonRepository.findByBuildingOrderByRecordedAtAsc(building);
+
+        return getBuildingUsageResult(carbonList);
     }
 }

--- a/src/test/java/com/capstone/carbonlive/repository/CarbonRepositoryTest.java
+++ b/src/test/java/com/capstone/carbonlive/repository/CarbonRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.capstone.carbonlive.repository;
+
+import com.capstone.carbonlive.entity.Building;
+import com.capstone.carbonlive.entity.Carbon;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CarbonRepositoryTest {
+
+    @Autowired CarbonRepository carbonRepository;
+    @Autowired BuildingRepository buildingRepository;
+
+    @Test
+    public void findByBuildingOrderByRecordedAtAsc() throws Exception {
+        //given
+        Building building = Building.builder()
+                .name("building1")
+                .gasArea(new BigDecimal(1111.11))
+                .elecArea(new BigDecimal(2222.22))
+                .gasDescription(null)
+                .elecDescription(null)
+                .build();
+        buildingRepository.save(building);
+        Building building2 = Building.builder()
+                .name("building2")
+                .gasArea(new BigDecimal(1111.11))
+                .elecArea(new BigDecimal(2222.22))
+                .gasDescription(null)
+                .elecDescription(null)
+                .build();
+        buildingRepository.save(building2);
+
+        carbonRepository.save(Carbon.builder()
+                .recordedAt(LocalDate.of(2022, 01, 01))
+                .usages(111)
+                .building(building)
+                .build());
+        carbonRepository.save(Carbon.builder()
+                .recordedAt(LocalDate.of(2022, 02, 01))
+                .usages(222)
+                .building(building)
+                .build());
+        carbonRepository.save(Carbon.builder()
+                .recordedAt(LocalDate.of(2022, 03, 01))
+                .usages(333)
+                .building(building2)
+                .build());
+
+        //when
+        List<Carbon> carbonList = carbonRepository.findByBuildingOrderByRecordedAtAsc(building);
+
+        //then
+        System.out.println("carbonList = " + carbonList);
+        assertThat(carbonList.size()).isEqualTo(2);
+        assertThat(carbonList.get(0).getUsages()).isEqualTo(111);
+        assertThat(carbonList.get(1).getUsages()).isEqualTo(222);
+    }
+
+}

--- a/src/test/java/com/capstone/carbonlive/service/CarbonServiceTest.java
+++ b/src/test/java/com/capstone/carbonlive/service/CarbonServiceTest.java
@@ -1,12 +1,14 @@
 package com.capstone.carbonlive.service;
 
 import com.capstone.carbonlive.dto.CarbonYearResponse;
+import com.capstone.carbonlive.dto.UsageResponse;
 import com.capstone.carbonlive.dto.UsageResult;
 import com.capstone.carbonlive.entity.Building;
 import com.capstone.carbonlive.entity.Carbon;
 import com.capstone.carbonlive.repository.BuildingRepository;
 import com.capstone.carbonlive.repository.CarbonRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -69,5 +71,23 @@ class CarbonServiceTest {
         assertThat(yearUsages.get(0).getUsages()).isEqualTo(27);
         assertThat(yearUsages.get(1).getYear()).isEqualTo(2019);
         assertThat(yearUsages.get(1).getUsages()).isEqualTo(333);
+    }
+
+    @Test
+    @DisplayName("건물별 탄소 배출량")
+   public void getBuildingUsages() throws Exception {
+        //when
+        Building findBuilding = buildingRepository.findByName("본관");
+        UsageResult<UsageResponse> result = carbonService.getBuildingUsages(findBuilding.getId());
+        List<UsageResponse> buildingUsages = result.getResult();
+
+        //then
+        System.out.println("buildingUsages = " + buildingUsages);
+        assertThat(buildingUsages.get(0).getYear()).isEqualTo(2017);
+        assertThat(buildingUsages.get(0).getUsages()[0]).isEqualTo(0);
+        assertThat(buildingUsages.get(0).getUsages()[6]).isEqualTo(27);
+        assertThat(buildingUsages.get(1).getYear()).isEqualTo(2019);
+        assertThat(buildingUsages.get(1).getUsages()[0]).isEqualTo(0);
+        assertThat(buildingUsages.get(1).getUsages()[6]).isEqualTo(57);
     }
 }


### PR DESCRIPTION
#### CarbonRepository.java
- 건물별 오름차순 정렬하여 리스트 반환하는 메서드 추가
- CarbonRepositoryTest 작성

#### CarbonServiceImpl.java
- 건물별 오름차순 정렬된 리스트를 연도별 분류하여 리스트 반환하는 메서드 추가
- CarbonServiceTest 작성

#### CarbonController.java
- 건물코드로 해당 건물의 연도별 리스트 반환하는 메서드 추가
- CarbonControllerTest 작성

#### GetUsageResult를 제네릭으로 만든 건 정말 최고다